### PR TITLE
Remove underscore before event and let events more natures resolved #1

### DIFF
--- a/node.go
+++ b/node.go
@@ -96,7 +96,7 @@ func (n *Node) markup(indent int) string {
 		b.WriteRune(' ')
 
 		if isMarkupEvent(name) {
-			b.WriteString(strings.TrimLeft(name, "_"))
+			b.WriteString(name)
 			b.WriteString(`="CallEvent('`)
 			b.WriteString(n.ID.String())
 			b.WriteString("', '")
@@ -147,7 +147,7 @@ func indentation(n int) string {
 }
 
 func isMarkupEvent(v string) bool {
-	return len(v) > 0 && v[0] == '_'
+	return strings.HasPrefix(v, "on")
 }
 
 func isComponentTag(tag string) bool {


### PR DESCRIPTION
Of course, all the articles and examples should be rewrite because of this.