### PR TITLE
refactor

### DIFF
--- a/render.go
+++ b/render.go
@@ -7,25 +7,30 @@ import (
 	"time"
 )
 
+// TemplateFuncMapper is the interface that wraps FuncMaps method.
 type TemplateFuncMapper interface {
+	// Allows to add custom functions to the template used to render the
+	// component.
+	// Note that funcs named json and time are already implemented to handle
+	// structs as prop and time format. Overload of these will be ignored.
+	// See https://golang.org/pkg/text/template/#Template.Funcs for more details.
 	FuncMaps() template.FuncMap
 }
 
 func render(c Componer) (rendered string, err error) {
 	var b bytes.Buffer
 
-	fnmap := template.FuncMap{
-		"json": convertToJSON,
-		"time": formatTime,
-	}
+	fnmap := template.FuncMap{}
 	if t, ok := c.(TemplateFuncMapper); ok {
 		extrafuncs := t.FuncMaps()
 		for k, v := range extrafuncs {
 			fnmap[k] = v
 		}
 	}
-	tmpl := template.Must(template.New("Render").Funcs(fnmap).Parse(c.Render()))
+	fnmap["json"] = convertToJSON
+	fnmap["time"] = formatTime
 
+	tmpl := template.Must(template.New("Render").Funcs(fnmap).Parse(c.Render()))
 	if err = tmpl.Execute(&b, c); err != nil {
 		return
 	}

--- a/render.go
+++ b/render.go
@@ -12,7 +12,7 @@ type TemplateFuncMapper interface {
 	// Allows to add custom functions to the template used to render the
 	// component.
 	// Note that funcs named json and time are already implemented to handle
-	// structs as prop and time format. Overload of these will be ignored.
+	// structs as prop and time format. Overloads of these will be ignored.
 	// See https://golang.org/pkg/text/template/#Template.Funcs for more details.
 	FuncMaps() template.FuncMap
 }

--- a/render_test.go
+++ b/render_test.go
@@ -1,7 +1,26 @@
 package markup
 
-import "testing"
-import "time"
+import (
+	"testing"
+	"text/template"
+	"time"
+)
+
+type CompoFuncMapper struct {
+	Greet string
+}
+
+func (c *CompoFuncMapper) Render() string {
+	return `<p>Hello, {{lunny .Greet}}!</p>`
+}
+
+func (c *CompoFuncMapper) FuncMaps() template.FuncMap {
+	return template.FuncMap{
+		"lunny": func(v interface{}) string {
+			return "Lunny"
+		},
+	}
+}
 
 func TestConvertToJSON(t *testing.T) {
 	t.Log(convertToJSON(42))
@@ -9,4 +28,17 @@ func TestConvertToJSON(t *testing.T) {
 
 func TestFormatTime(t *testing.T) {
 	t.Log(formatTime(time.Now(), "2006"))
+}
+
+func TestTemplateFuncMapper(t *testing.T) {
+	c := &CompoFuncMapper{Greet: "Maxence"}
+	expected := "<p>Hello, Lunny!</p>"
+
+	r, err := render(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r != expected {
+		t.Errorf("r should be %v: %v", expected, r)
+	}
 }


### PR DESCRIPTION
- unit test of TemplateFuncMapper component -> back to 100% test
coverage.
- godoc for TemplateFuncMapper
- ignore overload of json and time template funcs.